### PR TITLE
feat(security): Fix persistent XSS vulnerability in notice titles

### DIFF
--- a/app/Http/Controllers/Api/NoticeController.php
+++ b/app/Http/Controllers/Api/NoticeController.php
@@ -30,6 +30,7 @@ class NoticeController extends Controller
     {
         $notice = $request->input('notice');
         $notice['user_id'] = Auth::id();
+        $notice["title"] = htmlspecialchars($notice["title"], ENT_QUOTES, 'UTF-8');
         $notice['id'] = DB::table('notices')->insertGetId($notice);
         return ['ok' => 1, 'msg' => 'Created a new notice.', 'data' => $notice, 'redirect' => route('admin.notice.list', ['kw' => $notice['id']])];
     }
@@ -39,6 +40,7 @@ class NoticeController extends Controller
     {
         $notice = $request->input('notice');
         $notice['updated_at'] = date('Y-m-d H:i:s');
+        $notice["title"] = htmlspecialchars($notice["title"], ENT_QUOTES, "UTF-8");
         $ret = DB::table('notices')->where('id', $noticeId)->update($notice);
         if ($ret == 0) {
             return ['ok' => 0, 'msg' => 'Failed to update the notice.', 'data' => $notice, 'redirect' => route('admin.notice.list')];

--- a/resources/views/components/marquee.blade.php
+++ b/resources/views/components/marquee.blade.php
@@ -4,7 +4,7 @@
     onMouseOut="this.start()" onMouseOver="this.stop()">
     <a href="javascript:" onclick="get_marq_notice('{{ $notice->id }}')" data-toggle="modal"
       data-target="#home_notice">
-      {!! $notice->title !!}
+      {{ $notice->title }}
     </a>
   </marquee>
 


### PR DESCRIPTION
## 概述

无意间发现贵平台公告标题存在XSS漏洞，该漏洞允许有权限发布和修改公告的用户通过在公告标题中注入恶意脚本，从而在其他用户的浏览器中执行任意代码，导致严重的安全问题。

由于是持久型XSS，一旦恶意内容被存储，所有访问受影响页面的用户都可能成为攻击目标，影响范围广泛且难以控制。攻击者可以利用XSS漏洞窃取用户的Cookie、会话令牌或其他敏感信息，进而劫持用户会话，冒充合法用户执行操作。

故建议修复
